### PR TITLE
Add Open Climate Data Recommendations to best practices

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -156,6 +156,7 @@ This document contains a list of **Best Practices** recommendation for the [Open
 - [The 8 Principles of Open Government Data](https://opengovdata.org)
 - [U.S. Open Data Toolkit](https://usopendatatoolkit.org/best-practices-1)
 - [What is Open Data? - Practical Guide](https://opendatasoft.com/en/what-is-open-data-practical-guide)
+- [Recommendations for Better Sharing of Climate Data](https://creativecommons.org/2024/01/29/recommended-best-practices-for-better-sharing-of-climate-data/)
 
 ## Open Content
 


### PR DESCRIPTION
These are the Open Climate Data Recommendations from the Creative Commons. It's fairly straightforward and not too difficult to comply with, and it would be very helpful if more producers of climate data followed them.

(The new newline in the end was added by nano, should make no real difference.)